### PR TITLE
Enhance error handling for connection issues

### DIFF
--- a/obs_maven/repo.py
+++ b/obs_maven/repo.py
@@ -153,7 +153,13 @@ class Repo:
                 f.close()
                 os.utime(target, (mtime, mtime))
                 break
-            except (ConnectionResetError, urllib.error.HTTPError):
+            except (ConnectionResetError, ConnectionRefusedError, urllib.error.HTTPError) as e:
+                error_type = 
+                logging.debug(
+                    "Connection attempt failed for URL %s with error: %s.", 
+                    url, 
+                    type(e).__name__
+                )
                 if target_f:
                     target_f.close()
                     target_f = None


### PR DESCRIPTION
Added handling for ConnectionRefusedError in repo.py.

This PR aims to mitigate this particular issue while building uyuni server code.

```
     [exec] DEBUG:root:Getting binary from: https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Other/openSUSE_Leap_15.6/noarch/prometheus-client-java-0.3.0-1.115.uyuni3.noarch.rpm
     [exec] Traceback (most recent call last):
     [exec]   File "/usr/lib64/python3.6/urllib/request.py", line 1349, in do_open
     [exec]     encode_chunked=req.has_header('Transfer-encoding'))
(...)
     [exec]   File "/usr/lib64/python3.6/socket.py", line 713, in create_connection
     [exec]     sock.connect(sa)
     [exec] ConnectionRefusedError: [Errno 111] Connection refused
```