### PR TITLE
Avoid matching artifacts of other groups

### DIFF
--- a/obs_maven/artifact.py
+++ b/obs_maven/artifact.py
@@ -254,13 +254,23 @@ class Artifact:
         logging.info("Processing artifact %s" % self.artifact)
         file = self.get_binary()
 
+        if parse_pom:
+            # If we rely on parsing the pom, we need to download the package to know the exact
+            # groupId, hence the prefix for the artifact. This means we could potentially
+            # skip an rpm if two different jars have the same artifact id, different groups
+            # but same mtime
+            artifact_prefix = os.path.sep
+        else:
+            # Otherwise we use the default group to avoid matching artifacts of other groups
+            artifact_prefix = "%s%s%s" % (os.path.sep, self.default_group, os.path.sep)
+
         # Check if one of the artifact's jar has the same mtime. If so no need to update
         mtimes = [
             y
             for x in [
                 [os.stat(os.path.join(root, f)).st_mtime for f in files if f.endswith(".jar")]
                 for root, dirs, files in os.walk(repo)
-                if "%s%s%s" % (os.path.sep, self.artifact, os.path.sep) in root
+                if "%s%s%s" % (artifact_prefix, self.artifact, os.path.sep) in root
             ]
             for y in x
         ]


### PR DESCRIPTION
After the introduction of the `--parse-pom` flag, the way of handling the `groupId` of the artifacts has changed. This has introduced a bug because if the flag is omitted (i.e. when downloading dependencies for ant) the code currently look for existing jars in the whole designated repository folder, instead of only in the configured default group. This means `obs-to-maven` won't donwload a dependency if a jar already exists with a different group but same `mtime`. This scenario is currently happening with `commons-jexl.jar`.

This PR addresses this issue by using the previous search path when the flag is omitted. When the flag is specified, we cannot include the group id in the path to search artifacts because we don't know the group id until the dependency is downloaded and the group id is not the same anyway. Potentially, we could still hit the bug in `--parse-pom` mode if two packages contains an artifact with the same `artifactId`, different `groupId`, but the jar file has the same `mtime`.