### PR TITLE
Enable debugging for urllib

### DIFF
--- a/obs_maven/core.py
+++ b/obs_maven/core.py
@@ -34,52 +34,6 @@ from obs_maven._version import __version__
 logging.basicConfig(level=logging.INFO)
 
 
-class _DebugConnectionMixin:
-    """Mixin class that adds debug logging to HTTP connections"""
-    _protocol_name = "HTTP"
-
-    def send(self, data):
-        if isinstance(data, bytes):
-            # Only log if this looks like an HTTP request line (not body data)
-            first_line = data.split(b'\r\n', 1)[0]
-            # Check if it starts with a common HTTP method
-            if first_line.startswith((b'GET ', b'POST ', b'PUT ', b'DELETE ', b'HEAD ', b'PATCH ', b'OPTIONS ', b'CONNECT ')):
-                decoded_line = first_line.decode('ascii', errors='replace')
-                logging.debug("%s Request: %s", self._protocol_name, decoded_line)
-        return super().send(data)
-
-    def getresponse(self, *args, **kwargs):
-        response = super().getresponse(*args, **kwargs)
-        logging.debug("%s Response: %s %s", self._protocol_name, response.status, response.reason)
-        # Only log redirect if there's actually a Location header
-        location = response.getheader('Location')
-        if location:
-            logging.debug("%s Redirect to: %s", self._protocol_name, location)
-        return response
-
-
-class _DebugHTTPConnection(_DebugConnectionMixin, http.client.HTTPConnection):
-    """HTTPConnection subclass that logs debug info through Python logging"""
-    _protocol_name = "HTTP"
-
-
-class _DebugHTTPSConnection(_DebugConnectionMixin, http.client.HTTPSConnection):
-    """HTTPSConnection subclass that logs debug info through Python logging"""
-    _protocol_name = "HTTPS"
-
-
-class HTTPDebugHandler(urllib.request.HTTPHandler):
-    """Custom HTTP handler that enables debug output for urllib requests"""
-    def http_open(self, req):
-        return self.do_open(_DebugHTTPConnection, req)
-
-
-class HTTPSDebugHandler(urllib.request.HTTPSHandler):
-    """Custom HTTPS handler that enables debug output for urllib requests"""
-    def https_open(self, req):
-        return self.do_open(_DebugHTTPSConnection, req)
-
-
 class Configuration:
     def __init__(self, config_path, repo, cache_path, allowed_artifacts):
         data = {}

--- a/obs_maven/core.py
+++ b/obs_maven/core.py
@@ -16,12 +16,14 @@
 # You should have received a copy of the GNU General Public License
 
 import argparse
+import http.client
 import logging
 import os
 import os.path
 import shutil
 import sys
 import tempfile
+import urllib.request
 import yaml
 import xml.etree.ElementTree as ET
 
@@ -30,6 +32,52 @@ from obs_maven.artifact import Artifact
 from obs_maven._version import __version__
 
 logging.basicConfig(level=logging.INFO)
+
+
+class _DebugConnectionMixin:
+    """Mixin class that adds debug logging to HTTP connections"""
+    _protocol_name = "HTTP"
+
+    def send(self, data):
+        if isinstance(data, bytes):
+            # Only log if this looks like an HTTP request line (not body data)
+            first_line = data.split(b'\r\n', 1)[0]
+            # Check if it starts with a common HTTP method
+            if first_line.startswith((b'GET ', b'POST ', b'PUT ', b'DELETE ', b'HEAD ', b'PATCH ', b'OPTIONS ', b'CONNECT ')):
+                decoded_line = first_line.decode('ascii', errors='replace')
+                logging.debug("%s Request: %s", self._protocol_name, decoded_line)
+        return super().send(data)
+
+    def getresponse(self, *args, **kwargs):
+        response = super().getresponse(*args, **kwargs)
+        logging.debug("%s Response: %s %s", self._protocol_name, response.status, response.reason)
+        # Only log redirect if there's actually a Location header
+        location = response.getheader('Location')
+        if location:
+            logging.debug("%s Redirect to: %s", self._protocol_name, location)
+        return response
+
+
+class _DebugHTTPConnection(_DebugConnectionMixin, http.client.HTTPConnection):
+    """HTTPConnection subclass that logs debug info through Python logging"""
+    _protocol_name = "HTTP"
+
+
+class _DebugHTTPSConnection(_DebugConnectionMixin, http.client.HTTPSConnection):
+    """HTTPSConnection subclass that logs debug info through Python logging"""
+    _protocol_name = "HTTPS"
+
+
+class HTTPDebugHandler(urllib.request.HTTPHandler):
+    """Custom HTTP handler that enables debug output for urllib requests"""
+    def http_open(self, req):
+        return self.do_open(_DebugHTTPConnection, req)
+
+
+class HTTPSDebugHandler(urllib.request.HTTPSHandler):
+    """Custom HTTPS handler that enables debug output for urllib requests"""
+    def https_open(self, req):
+        return self.do_open(_DebugHTTPSConnection, req)
 
 
 class Configuration:
@@ -107,6 +155,10 @@ def main():
     args = parser.parse_args()
 
     logging.getLogger().setLevel(args.loglevel)
+    if args.loglevel == logging.DEBUG:
+        # Enable HTTP debugging by installing custom handlers
+        opener = urllib.request.build_opener(HTTPDebugHandler(), HTTPSDebugHandler())
+        urllib.request.install_opener(opener)
     logging.debug("Reading configuration")
     config = Configuration(args.config, args.out, args.cache, args.allowed_artifacts)
     tmp = tempfile.mkdtemp(prefix="obsmvn-")

--- a/obs_maven/core.py
+++ b/obs_maven/core.py
@@ -156,9 +156,16 @@ def main():
 
     logging.getLogger().setLevel(args.loglevel)
     if args.loglevel == logging.DEBUG:
-        # Enable HTTP debugging by installing custom handlers
-        opener = urllib.request.build_opener(HTTPDebugHandler(), HTTPSDebugHandler())
-        urllib.request.install_opener(opener)
+        # http.client.HTTPConnection.debuglevel is not respected by all Python versions
+        if sys.version_info >= (3, 12):
+            http.client.HTTPConnection.debuglevel = 1
+        else:
+            opener = urllib.request.build_opener(
+                urllib.request.HTTPHandler(debuglevel=1),
+                urllib.request.HTTPSHandler(debuglevel=1),
+            )
+            urllib.request.install_opener(opener)
+
     logging.debug("Reading configuration")
     config = Configuration(args.config, args.out, args.cache, args.allowed_artifacts)
     tmp = tempfile.mkdtemp(prefix="obsmvn-")


### PR DESCRIPTION
As of today, using `-d` or `--debug` does not offer debugging for the requests made using `urllib`.

This is needed for debugging connection issues, in particular when there are redirects involved.

We need this monkey patching because between Python 3.5.2 [1] and 3.11.X, Python stopped respecting `http.client.HTTPConnection.debuglevel`, and the fix [2] seems got only available starting with Python 3.12

When we start using only 3.12 and later, we can remove the import for `urllib.request` as well the condition for the python version and leave only the part for python >= 3.12

[1] https://stackoverflow.com/a/74416575
[2] https://github.com/python/cpython/pull/99353

**BEFORE:**
```
$ rm -rf test/; python3 -m obs_maven.core -d ../spacewalk/java/buildconf/ivy/obs-maven-config.yaml test -a antlr4-runtime
DEBUG:root:Reading configuration
INFO:root:Processing artifact antlr4-runtime
DEBUG:root:Parsing https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.6/repodata/repomd.xml
DEBUG:root:Loading RPMs from cache file: .obs-to-maven-cache/Uyuni/63cc3f113c0efce8106bf832c89795ff5111983a9e4bd5cea7742462e48c6221-primary.xml.gz.data
DEBUG:root:package mtime: 1775727845, []
INFO:root:Downloading /tmp/obsmvn-rwdr_yt4/antlr4-java-4.13.0-241000.1.12.uyuni5.noarch.rpm
DEBUG:root:Getting binary from: https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.6/noarch/antlr4-java-4.13.0-241000.1.12.uyuni5.noarch.rpm
DEBUG:root:not linked:
  /usr/share/doc/packages/antlr4-java
  /usr/share/doc/packages/antlr4-java/CHANGES.txt
  /usr/share/doc/packages/antlr4-java/README.md
  /usr/share/java/antlr4
  /usr/share/java/antlr4/antlr4-runtime.jar
  /usr/share/licenses/antlr4-java
  /usr/share/licenses/antlr4-java/LICENSE.txt
  /usr/share/maven-metadata/antlr4-antlr4-runtime.xml
  /usr/share/maven-poms/antlr4
  /usr/share/maven-poms/antlr4/antlr4-master.pom
  /usr/share/maven-poms/antlr4/antlr4-runtime.pom
DEBUG:root:full pattern: ^/usr/.*/antlr4-runtime[^/]*\.jar$
INFO:root:extracting /usr/share/java/antlr4/antlr4-runtime.jar to /tmp/obsmvn-rwdr_yt4/antlr4-runtime.jar
INFO:root:deploying /tmp/obsmvn-rwdr_yt4/antlr4-runtime.jar to test/suse/antlr4-runtime/4.13.0/antlr4-runtime-4.13.0.jar
DEBUG:root:Setting mtime 1775727845 on test/suse/antlr4-runtime/4.13.0/antlr4-runtime-4.13.0.jar
DEBUG:root:Computing test/suse/antlr4-runtime/4.13.0/antlr4-runtime-4.13.0.jar.sha1
DEBUG:root:Computing test/suse/antlr4-runtime/4.13.0/antlr4-runtime-4.13.0.pom.sha1
```

**AFTER:**
```
$ rm -rf test/; python3 -m obs_maven.core -d ../spacewalk/java/buildconf/ivy/obs-maven-config.yaml test -a antlr4-runtime
DEBUG:root:Reading configuration
INFO:root:Processing artifact antlr4-runtime
DEBUG:root:Parsing https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.6/repodata/repomd.xml
send: b'GET /repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.6/repodata/repomd.xml HTTP/1.1\r\nAccept-Encoding: identity\r\nHost: download.opensuse.org\r\nUser-Agent: Python-urllib/3.6\r\nConnection: close\r\n\r\n'
reply: 'HTTP/1.1 200 OK\r\n'
header: date: Tue, 21 Apr 2026 14:04:35 GMT
header: server: Mojolicious (Perl)
header: cache-control: public, max-age=75 stale-while-revalidate=63 stale-if-error=86400
header: content-disposition: inline;filename="repomd.xml"
header: content-length: 1725
header: content-type: application/xml;name="repomd.xml"
header: etag: 69E775D8-6BD
header: connection: close
DEBUG:root:Loading RPMs from cache file: .obs-to-maven-cache/Uyuni/0e68aeed259377a25d86f553d8297b774c5447b9274ef25b8cdd9363e527778c-primary.xml.gz.data
DEBUG:root:package mtime: 1776253846, []
INFO:root:Downloading /tmp/obsmvn-8cqahsps/antlr4-java-4.13.0-241000.1.13.uyuni5.noarch.rpm
DEBUG:root:Getting binary from: https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.6/noarch/antlr4-java-4.13.0-241000.1.13.uyuni5.noarch.rpm
send: b'GET /repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.6/noarch/antlr4-java-4.13.0-241000.1.13.uyuni5.noarch.rpm HTTP/1.1\r\nAccept-Encoding: identity\r\nHost: download.opensuse.org\r\nUser-Agent: Python-urllib/3.6\r\nConnection: close\r\n\r\n'
reply: 'HTTP/1.1 302 Found\r\n'
header: date: Tue, 21 Apr 2026 14:04:35 GMT
header: server: Mojolicious (Perl)
header: cache-control: public, max-age=300
header: content-length: 0
header: etag: 69DF7B68-4E8C4
header: location: https://ftp.gwdg.de/pub/opensuse/repositories/systemsmanagement%3A/Uyuni%3A/Master/openSUSE_Leap_15.6/noarch/antlr4-java-4.13.0-241000.1.13.uyuni5.noarch.rpm
header: vary: Accept,COUNTRY,X-COUNTRY,Fastly-SSL
header: x-media-version: 4.13.0
header: content-type: application/x-rpm
header: connection: close
send: b'GET /pub/opensuse/repositories/systemsmanagement%3A/Uyuni%3A/Master/openSUSE_Leap_15.6/noarch/antlr4-java-4.13.0-241000.1.13.uyuni5.noarch.rpm HTTP/1.1\r\nAccept-Encoding: identity\r\nHost: ftp.gwdg.de\r\nUser-Agent: Python-urllib/3.6\r\nConnection: close\r\n\r\n'
reply: 'HTTP/1.1 200 OK\r\n'
header: Server: nginx
header: Date: Tue, 21 Apr 2026 14:04:35 GMT
header: Content-Type: application/x-redhat-package-manager
header: Content-Length: 321732
header: Last-Modified: Wed, 15 Apr 2026 11:50:46 GMT
header: Connection: close
header: ETag: "69df7b96-4e8c4"
header: Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
header: X-Frame-Options: SAMEORIGIN
header: X-Content-Type-Options: nosniff
header: Accept-Ranges: bytes
DEBUG:root:not linked:
  /usr/share/doc/packages/antlr4-java
  /usr/share/doc/packages/antlr4-java/CHANGES.txt
  /usr/share/doc/packages/antlr4-java/README.md
  /usr/share/java/antlr4
  /usr/share/java/antlr4/antlr4-runtime.jar
  /usr/share/licenses/antlr4-java
  /usr/share/licenses/antlr4-java/LICENSE.txt
  /usr/share/maven-metadata/antlr4-antlr4-runtime.xml
  /usr/share/maven-poms/antlr4
  /usr/share/maven-poms/antlr4/antlr4-master.pom
  /usr/share/maven-poms/antlr4/antlr4-runtime.pom
DEBUG:root:full pattern: ^/usr/.*/antlr4-runtime[^/]*\.jar$
INFO:root:extracting /usr/share/java/antlr4/antlr4-runtime.jar to /tmp/obsmvn-8cqahsps/antlr4-runtime.jar
INFO:root:deploying /tmp/obsmvn-8cqahsps/antlr4-runtime.jar to test/suse/antlr4-runtime/4.13.0/antlr4-runtime-4.13.0.jar
DEBUG:root:Setting mtime 1776253846 on test/suse/antlr4-runtime/4.13.0/antlr4-runtime-4.13.0.jar
DEBUG:root:Computing test/suse/antlr4-runtime/4.13.0/antlr4-runtime-4.13.0.jar.sha1
DEBUG:root:Computing test/suse/antlr4-runtime/4.13.0/antlr4-runtime-4.13.0.pom.sha1
```

NOTE: Done with Claude assistance